### PR TITLE
Pipeline options improvements

### DIFF
--- a/aisynphys/pipeline/pipeline.py
+++ b/aisynphys/pipeline/pipeline.py
@@ -1,6 +1,6 @@
 import re
 from collections import OrderedDict
-from pyqtgraph import toposort
+from ..util import toposort
 from .pipeline_module import PipelineModule, DatabasePipelineModule
 
 

--- a/aisynphys/util.py
+++ b/aisynphys/util.py
@@ -19,12 +19,20 @@ stderr_log_handler.setLevel(logging.INFO)
 logger.addHandler(stderr_log_handler)
 
 def toposort(deps, nodes=None, seen=None, stack=None, depth=0):
-    """Topological sort. Arguments are:
-      deps    dictionary describing dependencies where a:[b,c] means "a depends on b and c"
-      nodes   optional, specifies list of starting nodes (these should be the nodes 
-              which are not depended on by any other nodes). Other candidate starting
-              nodes will be ignored.
-              
+    """Topological sort
+    
+    (credit: pyqtgraph) 
+    
+    Parameters
+    ----------
+    deps : dict
+        Dictionary describing dependencies where a:[b,c] means "a depends on b and c".
+    nodes : list | None
+        Optional; specifies list of starting nodes (these should be the nodes 
+        which are not depended on by any other nodes). Other candidate starting
+        nodes will be ignored.
+  
+
     Example::
 
         # Sort the following graph:

--- a/aisynphys/util.py
+++ b/aisynphys/util.py
@@ -18,6 +18,51 @@ stderr_log_handler = logging.StreamHandler()
 stderr_log_handler.setLevel(logging.INFO)
 logger.addHandler(stderr_log_handler)
 
+def toposort(deps, nodes=None, seen=None, stack=None, depth=0):
+    """Topological sort. Arguments are:
+      deps    dictionary describing dependencies where a:[b,c] means "a depends on b and c"
+      nodes   optional, specifies list of starting nodes (these should be the nodes 
+              which are not depended on by any other nodes). Other candidate starting
+              nodes will be ignored.
+              
+    Example::
+
+        # Sort the following graph:
+        # 
+        #   B ──┬─────> C <── D
+        #       │       │       
+        #   E <─┴─> A <─┘
+        #     
+        deps = {'a': ['b', 'c'], 'c': ['b', 'd'], 'e': ['b']}
+        toposort(deps)
+         => ['b', 'd', 'c', 'a', 'e']
+    """
+    # fill in empty dep lists
+    deps = deps.copy()
+    for k,v in list(deps.items()):
+        for k in v:
+            if k not in deps:
+                deps[k] = []
+    
+    if nodes is None:
+        ## run through deps to find nodes that are not depended upon
+        rem = set()
+        for dep in deps.values():
+            rem |= set(dep)
+        nodes = set(deps.keys()) - rem
+    if seen is None:
+        seen = set()
+        stack = []
+    sorted = []
+    for n in nodes:
+        if n in stack:
+            raise Exception("Cyclic dependency detected", stack + [n])
+        if n in seen:
+            continue
+        seen.add(n)
+        sorted.extend( toposort(deps, deps[n], seen, stack+[n], depth=depth+1))
+        sorted.append(n)
+    return sorted
 
 def datetime_to_timestamp(d):
     return time.mktime(d.timetuple()) + d.microsecond * 1e-6

--- a/util/analysis_pipeline.py
+++ b/util/analysis_pipeline.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     parser.add_argument('modules', type=str, nargs='*', help="The name of the analysis module(s) to run")
     parser.add_argument('--update', action='store_true', default=False, help="Process any jobs that are ready to be updated")
     parser.add_argument('--retry', action='store_true', default=False, help="During update, retry processing jobs that previously failed (implies --update)")
-    parser.add_argument('--force', action='store_true', default=False, help="During update, reprocess all available jobs even if up to date.")
+    parser.add_argument('--force-update', action='store_true', default=False, help="During update, reprocess all available jobs regardless of status (allowed only with --limit or --uids)")
     parser.add_argument('--report', action='store_true', default=False, help="Print a report of pipeline status and errors", )
     parser.add_argument('--rebuild', action='store_true', default=False, help="Remove and rebuild tables for selected modules")
     parser.add_argument('--workers', type=int, default=None, help="Set the number of concurrent processes during update")
@@ -93,13 +93,16 @@ if __name__ == '__main__':
         pipeline.drop(drop(modules=modules, job_ids=args.uids))
         print("  done.")
  
-    if args.update or args.rebuild or args.retry:
+    if args.update or args.rebuild or args.retry or args.force_update:
+        if args.force_update and (args.limit is None) and (args.uids is None):
+            print("Force-update permitted only with --uids or --limit options. Try rebuilding instead?")
+            sys.exit(-1)
         report = []
         for module in modules:
             print("=============================================")
             result = module.update(job_ids=args.uids, retry_errors=args.retry, limit=args.limit, 
                                    parallel=not args.local, workers=args.workers, debug=args.debug,
-                                   force=args.force)
+                                   force=args.force_update)
             report.append((module, result))
             
         if args.vacuum:

--- a/util/analysis_pipeline.py
+++ b/util/analysis_pipeline.py
@@ -88,18 +88,10 @@ if __name__ == '__main__':
             print("  Phooey.")
             args.bake = False
 
-    if args.rebuild:
-        pipeline.drop(modules)
+    if args.rebuild or args.drop:
+        # this call takes care of logging also
+        pipeline.drop(drop(modules=modules, job_ids=args.uids))
         print("  done.")
-
-    if args.drop:
-        for module in modules:
-            if args.uids is None:
-                print("Dropping and reinitializing module %s" % module.name)
-                module.drop_all(reinitialize=True)
-            else:
-                print("Dropping %d jobs in module %s" % (len(args.uids), module.name))
-                module.drop_jobs(job_ids=args.uids)
  
     if args.update or args.rebuild or args.retry:
         report = []

--- a/util/analysis_pipeline.py
+++ b/util/analysis_pipeline.py
@@ -16,6 +16,7 @@ if __name__ == '__main__':
     parser.add_argument('modules', type=str, nargs='*', help="The name of the analysis module(s) to run")
     parser.add_argument('--update', action='store_true', default=False, help="Process any jobs that are ready to be updated")
     parser.add_argument('--retry', action='store_true', default=False, help="During update, retry processing jobs that previously failed (implies --update)")
+    parser.add_argument('--force', action='store_true', default=False, help="During update, reprocess all available jobs even if up to date.")
     parser.add_argument('--report', action='store_true', default=False, help="Print a report of pipeline status and errors", )
     parser.add_argument('--rebuild', action='store_true', default=False, help="Remove and rebuild tables for selected modules")
     parser.add_argument('--workers', type=int, default=None, help="Set the number of concurrent processes during update")
@@ -104,7 +105,9 @@ if __name__ == '__main__':
         report = []
         for module in modules:
             print("=============================================")
-            result = module.update(job_ids=args.uids, retry_errors=args.retry, limit=args.limit, parallel=not args.local, workers=args.workers, debug=args.debug)
+            result = module.update(job_ids=args.uids, retry_errors=args.retry, limit=args.limit, 
+                                   parallel=not args.local, workers=args.workers, debug=args.debug,
+                                   force=args.force)
             report.append((module, result))
             
         if args.vacuum:


### PR DESCRIPTION
The toposort change is kind of out of place here, can remove if desired (but it does make it easier to run the pipeline remotely without errors in certain environments).

Primary change (adding --force): Right now --uids forces the selected job IDs to update, but we want --update --uids to only update the selected job ids IF they are out of date (same behavior as --update without --uids)

--update = only update if deps have changed
--retry = update if deps have changed OR the job failed on its last run
--force-update = update unconditionally; only allowed in combination with --uids or --limit
--rebuild = drop / rebuild tables in selected modules

In the process, also fixed some confusing logging of number of records dropped that will/won't be updated.

Also fixes the --drop option, which wasn't properly reinitializing when called without --uids.