### PR TITLE
move cortical_layer out of morphology

### DIFF
--- a/aisynphys/database/schema/cortical_location.py
+++ b/aisynphys/database/schema/cortical_location.py
@@ -12,7 +12,7 @@ CorticalCellLocation = make_table(
     columns=[
         ('cell_id', 'cell.id', 'ID of the cell these locations apply to.', {'index':True}),
         ('cortical_site_id', 'cortical_site.id', 'ID of the site location measurements fit within.', {'index':True}),
-        ('layer', 'str', 'Name of the layer the cell is in.'),
+        ('cortical_layer', 'str', 'Cortical layer of cell defined by layer drawings (after trimming, not identical to that in LIMS)', {'index': True}),
         ('distance_to_pia', 'float', 'The distance from the cell to the pial surface in m.'),
         ('distance_to_wm', 'float', 'The distance from the cell to the white matter in m.'),
         ('fractional_depth', 'float', 'The cortical depth of the cell where pia is 0 and wm is 1.'),

--- a/aisynphys/database/schema/morphology.py
+++ b/aisynphys/database/schema/morphology.py
@@ -10,7 +10,6 @@ Morphology = make_table(name='morphology', comment="Describes morphological prop
     ('pyramidal', 'bool', 'Indicates whether the experimenter labeled the cell as pyramidal. '
         'This call is based on the presence of a prominent apical dendrite seen in the fluorescent dye fill during experiment. '
         'The `dendrite_type` column is recommended as a more reliable indicator of excitatory morphology.', {'index': True}),
-    ('cortical_layer', 'str', 'Cortical layer of cell defined by layer drawing annotation based on DAPI staining', {'index': True}),
     ('qual_morpho_type', 'str', 'Qualitative desctription of cell morphology', {'index': True}),
     ('dendrite_type', 'str', 'Dendrite type of cell (spiny, aspiny, sparsely spiny) determined from biocytin staining. '
         'Generally spiny cells are taken to be excitatory; aspiny or sparsely spiny cells are inhibitory.', {'index': True}),


### PR DESCRIPTION
This removes the duplicate cortical_layer out of the morphology table, and renames the cortical_location layer to cortical_layer. This should let cell_class instances use the same criteria without modification. 
The one thing that still needs a fix is the dashboard - not sure if that should load the new one or from LIMS...